### PR TITLE
fix json parse data attributes

### DIFF
--- a/application/properties/views/properties-widget.php
+++ b/application/properties/views/properties-widget.php
@@ -125,7 +125,7 @@ $(function() {
     $("#properties-widget-%1$s .add-property-group").click(function() {
         var $form = $("#%2$s"),
             $this = $(this);
-        var data = JSON.parse($this.data('pg'));
+        var data = $this.data('pg');
         var $hidden = $('<input type="hidden">');
         $hidden.attr('name', '%3$s[' + data.form_name + ']').val(data.id);
         $form.append($hidden);
@@ -136,7 +136,7 @@ $(function() {
     $("#properties-widget-%1$s .remove-property-group").click(function() {
         var $form = $("#%2$s"),
             $this = $(this);
-        var data = JSON.parse($this.data('pg'));
+        var data = $this.data('pg');
         var $hidden = $('<input type="hidden">');
         $hidden.attr('name', '%4$s[' + data.form_name + ']').val(data.id);
         $form.append($hidden);


### PR DESCRIPTION
When the data attribute is an object (starts with '{') or array (starts with '[') then jQuery.parseJSON is used to parse the string; it must follow valid JSON syntax including quoted property names. If the value isn't parseable as a JavaScript value, it is left as a string.
https://api.jquery.com/data/#data-html5