### PR TITLE
introduce EventModule

### DIFF
--- a/application/config/common.php
+++ b/application/config/common.php
@@ -15,7 +15,8 @@ if (file_exists(__DIR__ . '/aliases.php')) {
 return [
     'timeZone' => 'Europe/Moscow',
     'bootstrap' => [
-        'mail'
+        'mail',
+        'event'
     ],
     'modules' => [
         'data' => [
@@ -31,6 +32,9 @@ return [
         'image' => [
             'class' => 'app\modules\image\ImageModule',
         ],
+        'event' => [
+            'class' => 'app\modules\event\EventModule'
+        ]
     ],
     'components' => [
         'db' => $db,

--- a/application/modules/event/EventModule.php
+++ b/application/modules/event/EventModule.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace app\modules\event;
+
+
+use app\components\BaseModule;
+use app\modules\event\interfaces\EventInterface;
+use yii\base\Application;
+use yii\base\BootstrapInterface;
+
+
+/**
+ * Class EventModule
+ * @package app\modules\event
+ *
+ * This module provide ability to attach custom handlers to any existing event from any module, even if module itself
+ * will not be bootstrapped
+ */
+class EventModule extends BaseModule implements BootstrapInterface
+{
+    /**
+     * Bootstrap method to be called during application bootstrap stage.
+     * @param Application $app the application currently running
+     */
+    public function bootstrap($app)
+    {
+        foreach ($app->modules as $module) {
+            if (is_object($module) && $module instanceof EventInterface) {
+                $module->attachEventsHandlers();
+            } elseif (is_array($module) && in_array(EventInterface::class, class_implements($module['class']), false)) {
+                $module['class']::attachEventsHandlers();
+            }
+        }
+    }
+}

--- a/application/modules/event/EventModule.php
+++ b/application/modules/event/EventModule.php
@@ -25,10 +25,9 @@ class EventModule extends BaseModule implements BootstrapInterface
     public function bootstrap($app)
     {
         foreach ($app->modules as $module) {
-            if (is_object($module) && $module instanceof EventInterface) {
-                $module->attachEventsHandlers();
-            } elseif (is_array($module) && in_array(EventInterface::class, class_implements($module['class']), false)) {
-                $module['class']::attachEventsHandlers();
+            $class = is_object($module) ? get_class($module) : $module['class'];
+            if (in_array(EventInterface::class, class_implements($class, false))) {
+                $class::attachEventsHandlers();
             }
         }
     }

--- a/application/modules/event/interfaces/EventInterface.php
+++ b/application/modules/event/interfaces/EventInterface.php
@@ -5,5 +5,8 @@ namespace app\modules\event\interfaces;
 
 interface EventInterface
 {
+    /**
+     * @return void
+     */
     public static function attachEventsHandlers();
 }

--- a/application/modules/event/interfaces/EventInterface.php
+++ b/application/modules/event/interfaces/EventInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace app\modules\event\interfaces;
+
+
+interface EventInterface
+{
+    public static function attachEventsHandlers();
+}


### PR DESCRIPTION
This module provide ability to attach custom handlers to any existing event from any module, even if module itself will not be bootstrapped

Usage:

1. implement `app\modules\event\interfaces\EventInterface` in your module
2. do anything you want in `YourModule::attachEventsHandlers` method
3. ???
4. PROFIT