### PR TITLE
Fix generate product options

### DIFF
--- a/application/modules/shop/controllers/BackendProductController.php
+++ b/application/modules/shop/controllers/BackendProductController.php
@@ -344,7 +344,9 @@ class BackendProductController extends BackendController
 
         if (isset($post['GeneratePropertyValue'])) {
             $generateValues = $post['GeneratePropertyValue'];
-            $post[HasProperties::FIELD_ADD_PROPERTY_GROUP]['Product'] = $post['PropertyGroup']['id'];
+            if(empty($parent->propertyGroups[$post['PropertyGroup']['id']])){
+                $post[HasProperties::FIELD_ADD_PROPERTY_GROUP]['Product'] = $post['PropertyGroup']['id'];
+            }
         } else {
             $generateValues = [];
         }


### PR DESCRIPTION
Баг при генерации опций продукта. Если родительскому продукту добавить группу свойств,  а потом по этой же группе с генерировать опции, в таблице `object_property_group` создается дубликат записи.

Добавлена проверка на наличие группы свойств у родительского продукта, перед добавлением группы для опции.