### PR TITLE
update dynamic content logic

### DIFF
--- a/application/traits/DynamicContentTrait.php
+++ b/application/traits/DynamicContentTrait.php
@@ -88,12 +88,8 @@ trait DynamicContentTrait
                         if ($model->h1) {
                             $dynamicResult['blocks']['h1'] = $model->h1;
                         }
-                        if ($model->announce) {
-                            $dynamicResult['blocks']['announce'] = $model->announce;
-                        }
-                        if ($model->content) {
-                            $dynamicResult['blocks'][$model->content_block_name] = $model->content;
-                        }
+                        $dynamicResult['blocks']['announce'] = $model->announce;
+                        $dynamicResult['blocks'][$model->content_block_name] = $model->content;
                     }
                 } else {
                     $matches = true;


### PR DESCRIPTION
Ситуация
есть `/catalog/category` с текстом и анонсом
и есть `/catalog/category/filter` с динамическим контентом в котором прописаны h1, title, description.

Что я ожидаю - отсутствие текста и анонса
Что я вижу - текст и анонс с категории + куча дублей текста на подобных страницах (фильтр + динамический контент без контента)

Почему в этом патче я не предлагаю то же для h1 - требует дополнительного исследования в каких-то случаях у нас в движке есть генерация h1 для страниц фильтров.