### PR TITLE
Fix JS error with enabled debug panel

### DIFF
--- a/application/modules/image/widgets/ImageDropzone.php
+++ b/application/modules/image/widgets/ImageDropzone.php
@@ -89,7 +89,7 @@ class ImageDropzone extends DropZone
     protected function createDropzone()
     {
         if (isset($this->options['url']) && is_array($this->options['url'])) {
-			$this->options['url'] = Url::to($this->options['url']);
+            $this->options['url'] = Url::to($this->options['url']);
         }
         $this->getView()->registerJs(
             'var ' . $this->dropzoneName . ' = new Dropzone("#' . $this->id . '", ' . Json::encode(

--- a/application/modules/image/widgets/ImageDropzone.php
+++ b/application/modules/image/widgets/ImageDropzone.php
@@ -88,6 +88,8 @@ class ImageDropzone extends DropZone
 
     protected function createDropzone()
     {
+		if( isset($this->options['url']) && is_array($this->options['url']) )
+			$this->options['url'] = Url::to($this->options['url']);
         $this->getView()->registerJs(
             'var ' . $this->dropzoneName . ' = new Dropzone("#' . $this->id . '", ' . Json::encode(
                 $this->options

--- a/application/modules/image/widgets/ImageDropzone.php
+++ b/application/modules/image/widgets/ImageDropzone.php
@@ -88,7 +88,7 @@ class ImageDropzone extends DropZone
 
     protected function createDropzone()
     {
-		if (isset($this->options['url']) && is_array($this->options['url'])) {
+        if (isset($this->options['url']) && is_array($this->options['url'])) {
 			$this->options['url'] = Url::to($this->options['url']);
         }
         $this->getView()->registerJs(

--- a/application/modules/image/widgets/ImageDropzone.php
+++ b/application/modules/image/widgets/ImageDropzone.php
@@ -88,8 +88,9 @@ class ImageDropzone extends DropZone
 
     protected function createDropzone()
     {
-		if( isset($this->options['url']) && is_array($this->options['url']) )
+		if (isset($this->options['url']) && is_array($this->options['url'])) {
 			$this->options['url'] = Url::to($this->options['url']);
+        }
         $this->getView()->registerJs(
             'var ' . $this->dropzoneName . ' = new Dropzone("#' . $this->id . '", ' . Json::encode(
                 $this->options


### PR DESCRIPTION
JS bug in `@app/modules/image/widgets/ImageDropzone.php`
current code make JS part of page:

```
"previewsContainer":"#w7","url":["upload"],"paramName":"file"});
then
Dropzone.uploadFiles call XMLHttpRequest.open with url === ["upload"]
```
but in 'debug' extension:
```
   XMLHttpRequest.prototype.open = function (method, url, async, user, pass) {
        var self = this;
        /* prevent logging AJAX calls to static and inline files, like templates */
        if (url.substr(0, 1) === '/' && !url.match(new RegExp("{{ excluded_ajax_paths }}"))) {

raise Error "TypeError: url.substr is not a function"
```