### PR TITLE
Пофиксен баг с правилом валидации required для полей с типом "файл"

### DIFF
--- a/application/actions/SubmitFormAction.php
+++ b/application/actions/SubmitFormAction.php
@@ -34,6 +34,34 @@ class SubmitFormAction extends Action
         }
 
         $post = Yii::$app->request->post();
+
+        // удаляем required правило для файлов
+        $intersectKeys = [];
+        if (isset($_FILES[$form->abstractModel->formName()]) && isset($post[$form->abstractModel->formName()])) {
+            $intersectKeys = array_intersect_key(
+                $post[$form->abstractModel->formName()],
+                $_FILES[$form->abstractModel->formName()]['name']
+            );
+        }
+        
+        if(!empty($intersectKeys)) {
+            $intersectKeys = array_keys($intersectKeys);
+            $oldRulesModel = $form->abstractModel->getRules();
+            $newRulesModel = [];
+            foreach($oldRulesModel as $curRule){
+                if(!is_array($curRule[1])
+                    && $curRule[1] == 'required'
+                    && in_array($curRule[0], $intersectKeys)) {
+                    continue;
+                }
+                $newRulesModel[] = $curRule;
+            }
+            $form->abstractModel->clearRules();
+            $form->abstractModel->addRules($newRulesModel);
+        }
+        // удаляем required правило для файлов
+
+
         $form->abstractModel->setAttributesValues($post);
         /** @var AbstractModel|SpamCheckerBehavior $model */
         $model = $form->getAbstractModel();

--- a/application/properties/AbstractModel.php
+++ b/application/properties/AbstractModel.php
@@ -94,6 +94,11 @@ class AbstractModel extends Model
         );
     }
 
+    public function getRules()
+    {
+        return $this->rules;
+    }
+
     public function addRules($rules)
     {
         $this->rules = ArrayHelper::merge($this->rules, $rules);


### PR DESCRIPTION
Проблема:
Проблема возникает, если сделать обязательным поле с загрузкой файла для формы. В валидации у модели ставится required, но при этом в post запросе данные о загруженном файле не передаются. В обработчике форм из поста заполняется абстрактная модель и дальше идёт валидация, которую пустое поле не проходит. 
Варианты решения:
1. Можно сделать поле не обязательным. А во views добавлять к нужному полю валидацию required.
2. В обработчике как-то удалить required rules из правил. Собственно данный pull request и удаляет данное правило, перебирая их все и отсеивая ненужные. 